### PR TITLE
Update enforce-openssl3.patch for openssh 9.8p1-2

### DIFF
--- a/patches/enforce-openssl3.patch
+++ b/patches/enforce-openssl3.patch
@@ -1,12 +1,12 @@
 diff --color -Naur b/debian/control a/debian/control
 --- b/debian/control	2024-05-07 12:24:10.531180124 +0200
 +++ a/debian/control	2024-05-07 12:25:07.303260447 +0200
-@@ -14,7 +14,7 @@
-                libkrb5-dev | heimdal-dev,
-                libpam0g-dev | libpam-dev,
-                libselinux1-dev [linux-any],
--               libssl-dev (>= 1.1.1),
-+               libssl-dev (>= 3.0.0),
-                libwrap0-dev | libwrap-dev,
-                pkgconf,
-                zlib1g-dev,
+@@ -15,7 +15,7 @@
+  libkrb5-dev | heimdal-dev,
+  libpam0g-dev | libpam-dev,
+  libselinux1-dev [linux-any],
+- libssl-dev (>= 1.1.1),
++ libssl-dev (>= 3.0.0),
+  libwrap0-dev | libwrap-dev,
+  pkgconf,
+  zlib1g-dev,


### PR DESCRIPTION
This version introduces `PerSourcePenalties`, cf:

https://metadata.ftp-master.debian.org/changelogs//main/o/openssh/openssh_9.8p1-2_changelog

```
    - sshd(8): penalise client addresses that, for various reasons, do not
      successfully complete authentication.  This feature is controlled by a
      new sshd_config(5) PerSourcePenalties option and is on by default.
```