### PR TITLE
Refs/heads/fix/build version 1 10.3p1 1

### DIFF
--- a/.container
+++ b/.container
@@ -1,0 +1,1 @@
+ghcr.io/gardenlinux/repo-debian-snapshot@sha256:99f72494ab45d33958a0385054de4742c7022ab07b4c0c2cef6f785f8ebfb378

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,0 @@
-Copyright 2020-2021 SAP SE &lt;gardenlinux@gardenlinux.io&gt;
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/prepare_source
+++ b/prepare_source
@@ -1,3 +1,17 @@
+# problem was / is: debian source doesn't provide the fixed package for https://security-tracker.debian.org/tracker/CVE-2026-35414, only for sid
+# source is then taken from salsa, but they keep their source code in a bit of a non straight forward way: https://wiki.debian.org/PackagingWithGit/GitDpm
+# as a result, the debian patches are already in the source code, but they also still exist in debian/patches.
+# one solution to that would be to keep as is and just not apply patches, another would be to reverse the patches before re-applying them
+# (this in principle would work, but not in a linear, atomar fashion, parts of one patch are already part of a second patch etc.)
+# 
+# what this now does is:
+#    check out the code from salsa to folder ~/ssh
+#    use uscan to determine the software version and
+#    download the source code of the package in the software version to ~/src
+#    copy the debian folder over from ~/ssh to ~/src
+#    then apply the patches within the debian folder
+
+
 (
 	debian_repo=https://salsa.debian.org/ssh-team/openssh.git
 	debian_ref="debian/1%10.3p1-1"

--- a/prepare_source
+++ b/prepare_source
@@ -1,2 +1,21 @@
-apt_src openssh
+(
+	debian_repo=https://salsa.debian.org/ssh-team/openssh.git
+	debian_ref="debian/1%10.3p1-1"
+
+	tmp_dir="$(mktemp -d)"
+	trap 'cd / && rm -rf "$tmp_dir"' EXIT
+	cd "$tmp_dir"
+
+	git clone --depth 1 --branch "$debian_ref" "$debian_repo" ssh
+	cd ssh
+
+	uscan -v --download-current-version
+
+	git clean -fdx
+
+	auto_decompress ../*.orig.tar.* | tee "$dir/orig.tar" | tar --extract --strip-components 1 --directory "$dir/src"
+	cp -r debian "$dir/src/"
+)
+
+apply_patches
 apply_patches

--- a/prepare_source
+++ b/prepare_source
@@ -18,4 +18,3 @@
 )
 
 apply_patches
-apply_patches


### PR DESCRIPTION
**What this PR does / why we need it**:
apt_src doesn't provide the fixed version for https://security-tracker.debian.org/tracker/CVE-2026-35414, but the version on salsa does

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/4612

**Special notes for your reviewer**:
See comment to explain what the code does
